### PR TITLE
Add first tests for PHP output

### DIFF
--- a/test/yaml/native.yaml
+++ b/test/yaml/native.yaml
@@ -19,7 +19,7 @@ tests:
           csharp: "new BsonDocument(\"x\", \"1\")"
           shell: "{\n  'x': '1'\n}"
           object: "{x: '1'}"
-          php: "(object)['x' => '1']"
+          php: "(object) ['x' => '1']"
     - input:
           javascript: "{x: '1',}"
           shell: "{x: '1',}"
@@ -31,6 +31,7 @@ tests:
           csharp: "new BsonDocument(\"x\", \"1\")"
           shell: "{\n  'x': '1'\n}"
           object: "{x: '1'}"
+          php: "(object) ['x' => '1']"
     - input:
           javascript: "{x: ['1', '2']}"
           shell: "{x: ['1', '2']}"
@@ -42,6 +43,7 @@ tests:
           csharp: "new BsonDocument(\"x\", new BsonArray\n    {\n        \"1\",\n        \"2\"\n    })"
           shell: "{\n  'x': [\n    '1', '2'\n  ]\n}"
           object: "{x: ['1', '2']}"
+          php: "(object) ['x' => ['1', '2']"
     - input:
           javascript: "{x: {y: 2}}"
           shell: "{x: {y: 2}}"
@@ -53,6 +55,7 @@ tests:
           csharp: "new BsonDocument(\"x\", new BsonDocument(\"y\", 2))"
           shell: "{\n  'x': {\n    'y': 2\n  }\n}"
           object: "{x: {y: 2}}"
+          php: "(object) ['x' => (object) ['y' => 2]]"
     - input:
           javascript: "{}"
           shell: "{}"
@@ -64,6 +67,7 @@ tests:
           java: "new Document()"
           csharp: "new BsonDocument()"
           object: "{}"
+          php: "(object) []"
     - input:
           javascript: "{x: '1', n: '4'}"
           shell: "{x: '1', n: '4'}"
@@ -75,6 +79,7 @@ tests:
           csharp: "new BsonDocument\n{\n    { \"x\", \"1\" }, \n    { \"n\", \"4\" }\n}"
           shell: "{\n  'x': '1', \n  'n': '4'\n}"
           object: "{x: '1', n: '4'}"
+          php: "(object) ['x' => 1, 'n' => 4]"
     - input:
           javascript: "{ graphLookup : { \"from\" : \"raw_data\", \"startWith\" : \"$_id\", \"connectFromField\" : \"_id\", \"connectToField\" : \"manager\", \"as\" : \"reports\" } }"
           shell: "{ graphLookup : { \"from\" : \"raw_data\", \"startWith\" : \"$_id\", \"connectFromField\" : \"_id\", \"connectToField\" : \"manager\", \"as\" : \"reports\" } }"
@@ -86,6 +91,7 @@ tests:
           csharp: "new BsonDocument(\"graphLookup\", new BsonDocument\n    {\n        { \"from\", \"raw_data\" }, \n        { \"startWith\", \"$_id\" }, \n        { \"connectFromField\", \"_id\" }, \n        { \"connectToField\", \"manager\" }, \n        { \"as\", \"reports\" }\n    })"
           shell: "{\n  'graphLookup': {\n    'from': 'raw_data', \n    'startWith': '$_id', \n    'connectFromField': '_id', \n    'connectToField': 'manager', \n    'as': 'reports'\n  }\n}"
           object: "{ graphLookup : { \"from\" : \"raw_data\", \"startWith\" : \"$_id\", \"connectFromField\" : \"_id\", \"connectToField\" : \"manager\", \"as\" : \"reports\" } }"
+          php: "(object) ['graphLookup' => (object) ['from' => 'raw_data', 'startWith' => '$_id', 'connectFromField' => '_id', 'connectToField' => 'manager', 'as' => 'reports']]"
     - input:
           javascript: "{ status: 'A', $or: [{ qty: { $lt: 30 } }, { item: { $regex: '^p' } }] }"
           shell: "{ status: 'A', $or: [{ qty: { $lt: 30 } }, { item: { $regex: '^p' } }] }"
@@ -97,6 +103,7 @@ tests:
           csharp: "new BsonDocument\n{\n    { \"status\", \"A\" }, \n    { \"$or\", new BsonArray\n    {\n        new BsonDocument(\"qty\", \n        new BsonDocument(\"$lt\", 30)),\n        new BsonDocument(\"item\", \n        new BsonDocument(\"$regex\", \"^p\"))\n    } }\n}"
           shell: "{\n  'status': 'A', \n  '$or': [\n    {\n      'qty': {\n        '$lt': 30\n      }\n    }, {\n      'item': {\n        '$regex': '^p'\n      }\n    }\n  ]\n}"
           object: "{ status: 'A', $or: [{ qty: { $lt: 30 } }, { item: { $regex: '^p' } }] }"
+          php: "(object) ['status' => 'A', '$or' => [(object) ['qty' => (object) ['$lt' => 30]], (object) ['item' => (object) ['$regex' => '^p']]]]"
     - input:
           python: "{ 'status': 'A', '$or': [{'qty': { '$lt': 30}}, {'item': { '$regex': '^p'}}]}"
       output:
@@ -106,6 +113,7 @@ tests:
           csharp: "new BsonDocument\n{\n    { \"status\", \"A\" }, \n    { \"$or\", new BsonArray\n    {\n        new BsonDocument(\"qty\", \n        new BsonDocument(\"$lt\", 30)),\n        new BsonDocument(\"item\", \n        new BsonDocument(\"$regex\", \"^p\"))\n    } }\n}"
           shell: "{\n  'status': 'A', \n  '$or': [\n    {\n      'qty': {\n        '$lt': 30\n      }\n    }, {\n      'item': {\n        '$regex': '^p'\n      }\n    }\n  ]\n}"
           object: "{ 'status': 'A', '$or': [{'qty': { '$lt': 30}}, {'item': { '$regex': '^p'}}]}"
+          php: "(object) ['status' => 'A', '$or' => [(object) ['qty' => (object) ['$lt' => 30]], (object) ['item' => (object) ['$regex' => '^p']]]]"
     Array:
     - input:
           python: "['1', '2']"
@@ -118,6 +126,7 @@ tests:
           shell: "[\n  '1', '2'\n]"
           python: "[\n    '1', '2'\n]"
           object: "['1', '2']"
+          php: "['1', '2']"
     - input:
           python: "['1', '2',]"
           javascript: "['1', '2',]"
@@ -129,6 +138,7 @@ tests:
           shell: "[\n  '1', '2'\n]"
           python: "[\n    '1', '2'\n]"
           object: "['1', '2']"
+          php: "['1', '2']"
     - input:
           python: "['1', { 'settings': 'http2' }]"
           javascript: "['1', { settings: 'http2' }]"
@@ -140,6 +150,7 @@ tests:
           shell: "[\n  '1', {\n    'settings': 'http2'\n  }\n]"
           python: "[\n    '1', {\n        'settings': 'http2'\n    }\n]"
           object: "['1', { settings: 'http2' }]"
+          php: "['1', (object) ['settings' => 'http2']]"
     - input:
           python: "{ 'pipeline': [{'$match': {'$expr': { '$eq': [ '$manager', '$$me' ] } } }, { '$project': { 'managers': 0}}, {'$sort': { 'startQuarter': 1, 'notes': 1, 'job_code': 1}}]}"
           javascript: "{\"pipeline\": [ { $match: { $expr: { \"$eq\": [ \"$manager\", \"$$me\" ] } } }, { $project: { managers : 0 } }, { $sort: { startQuarter: 1, notes:1, job_code: 1 } } ]}"
@@ -151,6 +162,7 @@ tests:
           shell: "{\n  'pipeline': [\n    {\n      '$match': {\n        '$expr': {\n          '$eq': [\n            '$manager', '$$me'\n          ]\n        }\n      }\n    }, {\n      '$project': {\n        'managers': 0\n      }\n    }, {\n      '$sort': {\n        'startQuarter': 1, \n        'notes': 1, \n        'job_code': 1\n      }\n    }\n  ]\n}"
           python: "{\n    'pipeline': [\n        {\n            '$match': {\n                '$expr': {\n                    '$eq': [\n                        '$manager', '$$me'\n                    ]\n                }\n            }\n        }, {\n            '$project': {\n                'managers': 0\n            }\n        }, {\n            '$sort': {\n                'startQuarter': 1, \n                'notes': 1, \n                'job_code': 1\n            }\n        }\n    ]\n}"
           object: "{\"pipeline\": [ { $match: { $expr: { \"$eq\": [ \"$manager\", \"$$me\" ] } } }, { $project: { managers : 0 } }, { $sort: { startQuarter: 1, notes:1, job_code: 1 } } ]}"
+          php: "(object) ['pipeline' => [(object) ['$match' => (object) ['$expr' => (object) ['$eq' => ['$manager', '$$me']]]], (object) ['$project' => (object) ['managers' => 0]], (object) ['$sort' => (object) ['startQuarter' => 1, 'notes' => 1, 'job_code' = 1]]]]"
     - input:
           python: "['1', ['2', '3']]"
           javascript: "['1', ['2', '3']]"
@@ -162,6 +174,7 @@ tests:
           shell: "[\n  '1', [\n    '2', '3'\n  ]\n]"
           python: "[\n    '1', [\n        '2', '3'\n    ]\n]"
           object: "['1', ['2', '3']]"
+          php: "['1', ['2', '3']]"
     - input:
           python: "[]"
           javascript: "[]"
@@ -173,6 +186,7 @@ tests:
           shell: "[]"
           python: "[]"
           object: "[]"
+          php: "[]"
     - input:
           python: "['1', ('2', '3')]"
       output:
@@ -182,6 +196,7 @@ tests:
           shell: "[\n  '1', [\n    '2', '3'\n  ]\n]"
           python: "[\n    '1', [\n        '2', '3'\n  ]\n]"
           object: "['1', ['2', '3']]"
+          php: "['1', ['2', '3']]"
     ArrayElision:
     - input:
           javascript: "[,'1', '2',]"
@@ -193,6 +208,7 @@ tests:
           shell: "[\n  undefined, '1', '2'\n]"
           javascript: "[\n  undefined, '1', '2'\n]"
           object: "[undefined, '1', '2']"
+          php: "[null, '1', '2']"
     - input:
           javascript: "[,]"
           shell: "[,]"
@@ -203,6 +219,7 @@ tests:
           shell: "[\n  undefined\n]"
           javascript: "[\n  undefined\n]"
           object: "[undefined]"
+          php: "[null]"
     - input:
           javascript: "[,,]"
           shell: "[,,]"
@@ -213,6 +230,7 @@ tests:
           shell: "[\n  undefined, undefined\n]"
           javascript: "[\n  undefined, undefined\n]"
           object: "[undefined, undefined]"
+          php: "[null, null]"
     - input:
           javascript: "['1',,,,'2']"
           shell: "['1',,,,'2']"
@@ -223,6 +241,7 @@ tests:
           shell: "[\n  '1', undefined, undefined, undefined, '2'\n]"
           javascript: "[\n  '1', undefined, undefined, undefined, '2'\n]"
           object: "['1', undefined, undefined, undefined, '2']"
+          php: "['1', null, null, null, '2']"
     Tuple:
     - input:
           python: "()"
@@ -233,6 +252,7 @@ tests:
           csharp: "new BsonArray()"
           shell: "[]"
           object: "[]"
+          php: "[]"
     - input:
           python: "(1,)"
       output:
@@ -242,6 +262,7 @@ tests:
           csharp: "new BsonArray\n{\n    1\n}"
           shell: "[\n  1\n]"
           object: "[1]"
+          php: "[1]"
     - input:
           python: "(1)"
       output:
@@ -251,6 +272,7 @@ tests:
           csharp: "(1)"
           shell: "(1)"
           object: "(1)"
+          php: "(1)"
     - input:
           python: "('1', { 'settings': 'http2' })"
       output:
@@ -260,6 +282,7 @@ tests:
           csharp: "new BsonArray\n{\n    \"1\",\n    new BsonDocument(\"settings\", \"http2\")\n}"
           shell: "[\n  '1', {\n    'settings': 'http2'\n  }\n]"
           object: "['1', { 'settings': 'http2' }]"
+          php: "['1', (object) ['settings' => 'http2']]"
     - input:
           python: "('1', ['2', '3'])"
       output:
@@ -269,6 +292,7 @@ tests:
           csharp: "new BsonArray\n{\n    \"1\",\n    new BsonArray\n    {\n        \"2\",\n        \"3\"\n    }\n}"
           shell: "[\n  '1', [\n    '2', '3'\n  ]\n]"
           object: "['1', ['2', '3']]"
+          php: "['1', ['2', '3']]"
     - input:
           python: "['1', ('2', '3')]"
       output:
@@ -278,6 +302,7 @@ tests:
           csharp: "new BsonArray\n{\n    \"1\",\n    new BsonArray\n    {\n        \"2\",\n        \"3\"\n    }\n}"
           shell: "[\n  '1', [\n    '2', '3'\n  ]\n]"
           object: "['1', ['2', '3']]"
+          php: "['1', ['2', '3']]"
     binops:
     - input:
           javascript: 2 + 5 - 1
@@ -290,6 +315,7 @@ tests:
           java: 2L + 5L - 1L
           csharp: 2 + 5 - 1
           object: 2 + 5 - 1
+          php: 2 + 5 - 1
     - input:
           javascript: 2 + (4 * 36) / 3
           shell: 2 + (4 * 36) / 3
@@ -302,6 +328,7 @@ tests:
           java: 2L + (4L * 36L) / 3L
           csharp: 2 + (4 * 36) / 3
           object: 2 + (4 * 36) / 3
+          php: 2 + (4 * 36) / 3
     - input:
           python: 10 // 2 % 3
       output:
@@ -311,6 +338,7 @@ tests:
           java: floor(10L) % 3L
           csharp: Math.floor(10, 2) % 3
           object: Math.floor(10, 2)%3
+          php: floor(10 / 2)%3
     - input:
           python: 6 ** 7
       output:
@@ -320,6 +348,7 @@ tests:
           java: pow(6L, 7L)
           csharp: Math.pow(6, 7)
           object: Math.pow(6, 7)
+          php: 6 ** 7
     - input:
           javascript: 1 | 2 ^ 3 & 4 << 6 >> 7
           shell: 1 | 2 ^ 3 & 4 << 6 >> 7
@@ -331,6 +360,7 @@ tests:
           java: 1L | 2L ^ 3L & 4L << 6L >> 7L
           csharp: 1 | 2 ^ 3 & 4 << 6 >> 7
           object: 1 | 2 ^ 3 & 4 << 6 >> 7
+          php: 1 | 2 ^ 3 & 4 << 6 >> 7
     - input:
           javascript: 2 + +5- -6
           shell: 2 + +5- -6
@@ -342,6 +372,7 @@ tests:
           java: 2L + +5L - -6L
           csharp: 2 + +5 - -6
           object: 2 + +5 - -6
+          php: 2 + +5 - -6
     unaryops:
     - input:
           javascript: '+1'
@@ -354,6 +385,7 @@ tests:
           java: '+1L'
           csharp: '+1'
           object: '+1'
+          php: '+1'
     - input:
           javascript: '-1'
           shell: '-1'
@@ -365,6 +397,7 @@ tests:
           java: '-1L'
           csharp: '-1'
           object: '-1'
+          php: '-1'
     - input:
           javascript: '~1'
           shell: '~1'
@@ -376,6 +409,7 @@ tests:
           java: '~1L'
           csharp: '~1'
           object: '~1'
+          php: '~1'
     Number:
     - input:
           javascript: new Number(2)
@@ -387,6 +421,7 @@ tests:
           java: 2d
           csharp: (int) 2
           object: Number(2)
+          php: (int) 2
     - input:
           javascript: Number(2)
           shell: Number(2)
@@ -397,6 +432,7 @@ tests:
           java: 2d
           csharp: (int) 2
           object: Number(2)
+          php: (int) 2
     - input:
           javascript: Number('2')
           shell: Number('2')
@@ -407,6 +443,7 @@ tests:
           java: Double.parseDouble("2")
           csharp: int.Parse("2")
           object: Number(2)
+          php: (int) '2'
     - input:
           shell: Number()
       output:
@@ -416,6 +453,7 @@ tests:
           java: 0d
           csharp: (int) 0
           object: '0'
+          php: (int) 0
     numeric_literals:
     - input:
           javascript: '2'
@@ -428,6 +466,7 @@ tests:
           java: '2L'
           csharp: '2'
           object: '2'
+          php: '2'
     - input:
           javascript: '429496729601'
           shell: '429496729601'
@@ -439,6 +478,7 @@ tests:
           java: '429496729601L'
           csharp: '429496729601'
           object: '429496729601'
+          php: '429496729601'
     - input:
           javascript: '2.001'
           shell: '2.001'
@@ -450,6 +490,7 @@ tests:
           java: '2.001d'
           csharp: '2.001'
           object: '2.001'
+          php: '2.001'
     - input:
           javascript: '0X123ABC'
           shell: '0X123ABC'
@@ -461,6 +502,7 @@ tests:
           java: '0X123ABC'
           csharp: '0X123ABC'
           object: '0X123ABC'
+          php: '0X123ABC'
     - input:
           javascript: '0x123abc'
           shell: '0x123abc'
@@ -472,6 +514,7 @@ tests:
           java: '0x123abc'
           csharp: '0x123abc'
           object: '0x123abc'
+          php: '0x123abc'
     - input:
           javascript: '0o1234567'
           shell: '0o1234567'
@@ -483,6 +526,7 @@ tests:
           java: '01234567'
           csharp: '342391'
           object: '0o1234567'
+          php: '01234567'
     - input:
           javascript: '01234567'
           shell: '01234567'
@@ -493,6 +537,7 @@ tests:
           java: '01234567'
           csharp: '342391'
           object: '01234567'
+          php: '01234567'
     - input:
           javascript: '001234567'
           shell: '001234567'
@@ -503,6 +548,7 @@ tests:
           java: '01234567'
           csharp: '342391'
           object: '001234567'
+          php: '01234567'
     - input:
           javascript: '0O1234567'
           shell: '0O1234567'
@@ -514,6 +560,7 @@ tests:
           java: '01234567'
           csharp: '342391'
           object: '0O1234567'
+          php: '01234567'
     misc_literals:
     - input:
           javascript: 'true'
@@ -526,6 +573,7 @@ tests:
           java: 'true'
           csharp: 'true'
           object: 'true'
+          php: 'true'
     - input:
           javascript: 'false'
           shell: 'false'
@@ -537,6 +585,7 @@ tests:
           java: 'false'
           csharp: 'false'
           object: 'false'
+          php: 'false'
     - input:
           javascript: 'null'
           shell: 'null'
@@ -548,6 +597,7 @@ tests:
           java: 'new BsonNull()'
           csharp: 'BsonNull.Value'
           object: 'null'
+          php: 'null'
     - input:
           javascript: 'undefined'
           shell: 'undefined'
@@ -558,6 +608,7 @@ tests:
           java: 'new BsonUndefined()'
           csharp: 'BsonUndefined.Value'
           object: 'undefined'
+          php: 'null'
     string_literals:
     - input:
           javascript: "'string'"
@@ -570,6 +621,7 @@ tests:
           java: "\"string\""
           csharp: "\"string\""
           object: "'string'"
+          php: "'string'"
     - input:
           javascript: "\"string\""
           shell: "\"string\""
@@ -581,6 +633,7 @@ tests:
           java: "\"string\""
           csharp: "\"string\""
           object: "\"string\""
+          php: "\"string\""
     python_strings:
     - input:
           python: "'''string'''"
@@ -590,6 +643,7 @@ tests:
           csharp": "\"string\""
           shell": "'string'"
           object: "\"string\""
+          php": "'string'"
     - input:
           python: "\"\"\"string\"\"\""
       output:
@@ -598,6 +652,7 @@ tests:
           csharp: "\"string\""
           shell: "'string'"
           object: "\"string\""
+          php: "'string'"
     - input:
         python: "b'abc'"
       output:
@@ -606,6 +661,7 @@ tests:
           csharp: "\"abc\""
           shell: "'abc'"
           object: "'abc'"
+          php: "'abc'"
     - input:
         python: "B'abc'"
       output:
@@ -614,6 +670,7 @@ tests:
           csharp: "\"abc\""
           shell: "'abc'"
           object: "\"abc\""
+          php: "'abc'"
     - input:
         python: "b\"abc\""
       output:
@@ -622,6 +679,7 @@ tests:
           csharp: "\"abc\""
           shell: "'abc'"
           object: "\"abc\""
+          php: "'abc'"
     - input:
           python: "B'abc'"
       output:
@@ -630,6 +688,7 @@ tests:
           csharp: "\"abc\""
           shell: "'abc'"
           object: "\"abc\""
+          php: "'abc'"
     - input:
           python: "u'abc'"
       output:
@@ -646,6 +705,7 @@ tests:
           csharp: "\"abc\""
           shell: "'abc'"
           object: "\"abc\""
+          php: "'abc'"
     - input:
           python: "u\"abc\""
       output:
@@ -654,6 +714,7 @@ tests:
           csharp: "\"abc\""
           shell: "'abc'"
           object: "\"abc\""
+          php: "'abc'"
     - input:
           python: "U'abc'"
       output:
@@ -662,6 +723,7 @@ tests:
           csharp: "\"abc\""
           shell: "'abc'"
           object: "\"abc\""
+          php: "'abc'"
     - input:
           python: "fR'abc'"
       output:
@@ -670,6 +732,7 @@ tests:
           csharp: "\"abc\""
           shell: "'abc'"
           object: "\"abc\""
+          php: "'abc'"
     - input:
           python: "rB'abc'"
       output:
@@ -678,6 +741,7 @@ tests:
           csharp: "\"abc\""
           shell: "'abc'"
           object: "\"abc\""
+          php: "'abc'"
     # TODO: unescape escaped quotes
     number_methods:
     - input:
@@ -689,6 +753,7 @@ tests:
           java: '3'
           csharp: '3'
           object: 'new Int32(3)'
+          php: '3'
     - input:
           python: int('3')
       output:
@@ -698,6 +763,7 @@ tests:
           java: Integer.parseInt("3")
           csharp: Convert.ToInt32("3")
           object: new Int32('3')
+          php: (int) '3'
     - input:
           python: int(3.001)
       output:
@@ -707,6 +773,7 @@ tests:
           java: (int) 3.001d
           csharp: Convert.ToInt32(3.001)
           object: 'new Int32(3.001)'
+          php: (int) 3.001
     - input:
           python: int(0x3)
       output:
@@ -716,6 +783,7 @@ tests:
           java: (int) 0x3
           csharp: Convert.ToInt32(0x3)
           object: 'new Int32(0x3)'
+          php: (int) 0x3
     - input:
           python: int(0o3)
       output:
@@ -725,6 +793,7 @@ tests:
           java: (int) 03
           csharp: '3'
           object: 'new Int32(0o3)'
+          php: (int) 03
     - input:
           python: float(3)
       output:
@@ -734,6 +803,7 @@ tests:
           java: '3d'
           csharp: '3.0'
           object: new Double(3)
+          php: (float) 3
     - input:
           python: float('3')
       output:
@@ -743,6 +813,7 @@ tests:
           java: Double.parseDouble("3")
           csharp: Convert.ToDouble("3")
           object: new Double('3')
+          php: (float) 3
     - input:
           python: float(3.001)
       output:
@@ -752,6 +823,7 @@ tests:
           java: 3.001d
           csharp: '3.001'
           object: new Double(3.001)
+          php: 3.001
     - input:
           python: float(0x3)
       output:
@@ -761,6 +833,7 @@ tests:
           java: (double) 0x3
           csharp: Convert.ToDouble(0x3)
           object: new Double(0x3)
+          php: (float) 0x3
     - input:
           python: float(0o3)
       output:
@@ -770,6 +843,7 @@ tests:
           java: (double) 03
           csharp: '3.0'
           object: new Double(0o3)
+          php: (float) 03
     Date:
     - description: now date
       input:

--- a/test/yaml/syntax.yaml
+++ b/test/yaml/syntax.yaml
@@ -19,6 +19,7 @@ tests:
           java: "1L + 2L"
           csharp: "1 + 2"
           object: "3"
+          php: "1 + 2"
     - input:
           javascript: "1 \n +2"
           shell: "1 \t\t +2"
@@ -30,6 +31,7 @@ tests:
           java: "1L + 2L"
           csharp: "1 + 2"
           object: "3"
+          php: "1 + 2"
     compare:
     - input:
           javascript: "1 === 2"
@@ -42,6 +44,7 @@ tests:
           java: "1L == 2L"
           csharp: "1 == 2"
           object: "false"
+          php: "1 === 2"
     - input:
           javascript: "1 !== 2"
           shell: "1 !== 2"
@@ -53,6 +56,7 @@ tests:
           java: "1L != 2L"
           csharp: "1 != 2"
           object: "true"
+          php: "1 !== 2"
     - input:
           javascript: "true || false"
           shell: "true || false"
@@ -64,6 +68,7 @@ tests:
           java: "true || false"
           csharp: "true || false"
           object: "true"
+          php: "true || false"
     - input:
           javascript: "true || false || true"
           shell: "true || false || true"
@@ -75,6 +80,7 @@ tests:
           java: "true || false || true"
           csharp: "true || false || true"
           object: "true"
+          php: "true || false || true"
     - input:
           javascript: "true && false"
           shell: "true && false"
@@ -86,6 +92,7 @@ tests:
           java: "true && false"
           csharp: "true && false"
           object: "false"
+          php: "true && false"
     - input:
           javascript: "true && false && true"
           shell: "true && false && true"
@@ -97,6 +104,7 @@ tests:
           java: "true && false && true"
           csharp: "true && false && true"
           object: "false"
+          php: "true && false && true"
     - input:
           javascript: "!true"
           shell: "!true"
@@ -108,6 +116,7 @@ tests:
           java: "!true"
           csharp: "!true"
           object: "false"
+          php: "!true"
     - input:
           javascript: "1 > 2 < 3 >= 4 <= 6"
           shell: "1 > 2 < 3 >= 4 <= 6"
@@ -119,6 +128,7 @@ tests:
           java: "1L > 2L < 3L >= 4L <= 6L" # TODO: this is wrong
           csharp: "1 > 2 < 3 >= 4 <= 6"
           object: "true"
+          php: "1 > 2 < 3 >= 4 <= 6"
     - input:
           python: "4 is 5"
       output:
@@ -128,6 +138,7 @@ tests:
           java: "4L == 5L"
           csharp: "4 == 5"
           object: "false"
+          php: "4 === 5"
     - input:
           python: "4 is not 5"
       output:
@@ -137,6 +148,7 @@ tests:
           java: "4L != 5L"
           csharp: "4 != 5"
           object: "true"
+          php: "4 !== 5"
     - input:
           python: "4 in [1, 2]"
       output:
@@ -146,6 +158,7 @@ tests:
           java: "Arrays.asList(1L, 2L).contains(4L)"
           csharp: "new BsonArray\n{\n    1,\n    2\n}.indexOf(4) != -1"
           object: "false"
+          php: "in_array(4, [1, 2], true)"
     - input:
           python: "4 not in [1, 2]"
       output:
@@ -155,6 +168,7 @@ tests:
           java: "!Arrays.asList(1L, 2L).contains(4L)"
           csharp: "new BsonArray\n{\n    1,\n    2\n}.indexOf(4) == -1"
           object: "true"
+          php: "!in_array(4, [1, 2], true)"
     comments:
     - input:
           javascript: "1 // a comment"
@@ -167,6 +181,7 @@ tests:
           java: "1L"
           csharp: "1"
           object: "1"
+          php: "1"
     - input:
           javascript: "1 /* a comment*/"
           shell: "1 /* a comment*/"
@@ -177,6 +192,7 @@ tests:
           java: "1L"
           csharp: "1"
           object: "1"
+          php: "1"
     - input:
           javascript: "1 /* a \ncom\nmen\nt*/+2"
           shell: "1 /* a \ncom\nmen\nt*/+2"
@@ -187,6 +203,7 @@ tests:
           java: "1L + 2L"
           csharp: "1 + 2"
           object: "3"
+          php: "1 + 2"
     - input:
           javascript: "1 /* a \ncom\nmen\nt*/"
           shell: "1 /* a \ncom\nmen\nt*/"
@@ -197,6 +214,7 @@ tests:
           java: "1L"
           csharp: "1"
           object: "1"
+          php: "1"
     - input:
           javascript: "1 /* a comment*/+2"
           shell: "1 /* a comment*/+2"
@@ -207,6 +225,7 @@ tests:
           java: "1L + 2L"
           csharp: "1 + 2"
           object: "3"
+          php: "1 + 2"
     parens:
     - input:
           javascript: "(1 === 1)"
@@ -219,6 +238,7 @@ tests:
           java: "(1L == 1L)"
           csharp: "(1 == 1)"
           object: "true"
+          php: "(1 === 1)"
     - input:
           javascript: "((1 === (1)))"
           shell: "((1 === (1)))"
@@ -230,3 +250,4 @@ tests:
           java: "((1L == (1L)))"
           csharp: "((1 == (1)))"
           object: "true"
+          php: "((1 === (1)))"


### PR DESCRIPTION
This is the first set of test output. Changes from the initial prototype template for objects and arrays:
* Added space after typecast
* Removed indentation as it's not necessary (relict of copying from Python)

For PHP, we always use single quotes to avoid having to check the input for `$` which carries special significance in double-quoted strings.